### PR TITLE
refactor: Huge improvement in folder tree logic

### DIFF
--- a/ViewModels/FolderViewModel.cs
+++ b/ViewModels/FolderViewModel.cs
@@ -37,8 +37,18 @@ namespace FileCraft.ViewModels
             {
                 if (_isProcessingSelectionChange) return;
 
-                bool newSelectionValue = (_isSelected != true);
-                SetIsSelected(newSelectionValue, updateChildren: true, updateParent: true);
+                _isProcessingSelectionChange = true;
+                try
+                {
+                    bool newSelectionValue = (_isSelected != true);
+                    SetIsSelected(newSelectionValue, updateChildren: true, updateParent: true);
+                }
+                finally
+                {
+                    _isProcessingSelectionChange = false;
+                }
+
+                _onStateChanged?.Invoke();
             }
         }
 
@@ -56,29 +66,20 @@ namespace FileCraft.ViewModels
         {
             if (_isSelected == value) return;
 
-            _isProcessingSelectionChange = true;
-            try
+            _isSelected = value;
+            OnPropertyChanged(nameof(IsSelected));
+
+            if (updateChildren)
             {
-                _isSelected = value;
-                OnPropertyChanged(nameof(IsSelected));
-                _onStateChanged?.Invoke();
-
-                if (updateChildren)
+                foreach (var child in Children)
                 {
-                    foreach (var child in Children)
-                    {
-                        child.SetIsSelected(value, true, false);
-                    }
-                }
-
-                if (updateParent && Parent != null)
-                {
-                    Parent.VerifyCheckState();
+                    child.SetIsSelected(value, true, false);
                 }
             }
-            finally
+
+            if (updateParent && Parent != null)
             {
-                _isProcessingSelectionChange = false;
+                Parent.VerifyCheckState();
             }
         }
 


### PR DESCRIPTION
Now the "Extension" check and "File Path" check (from File Contents Export tab) are only run once, after the Folde Tree is completed the check/uncheck action. Previously it was for EVERY SINGLE check-uncheck WHILE the process was going. So if we checked in a parent folder that had 1000 child folders, then it went through all 1000 children folders to check them too, and do 1000 update for Extensions and another 1000 update for File Path. Now they only do 1 update for Extension and File Path AFTER the Folder Tree finsihed it's process.